### PR TITLE
BREAKING CHANGE: replace resursive search with JSON pointer

### DIFF
--- a/mqttSup/src/drvMqtt.cpp
+++ b/mqttSup/src/drvMqtt.cpp
@@ -256,13 +256,7 @@ void MqttDriver::onMessageCb(Autoparam::Driver* driver, const std::string& topic
     if (addr.format == MqttTopicAddr::JSON) {
       try {
         json root = json::parse(payload);
-        const json* fieldAddr = findJsonField(root, addr.jsonField);
-        if (!fieldAddr || fieldAddr->is_null())
-          throw std::invalid_argument("JSON field not found: " + addr.jsonField);
-        if (fieldAddr->is_string())
-          val = fieldAddr->get<std::string>();
-        else
-          val = fieldAddr->dump();
+        val = to_string(root.at(json::json_pointer(addr.jsonField)));
       }
       catch (const std::exception& e) {
         asynPrint(pself->pasynUserSelf, ASYN_TRACE_ERROR,
@@ -327,28 +321,6 @@ void MqttDriver::onMessageCb(Autoparam::Driver* driver, const std::string& topic
 }
 //#############################################################################################
 // Helper methods
-
-// Recursively search for a key anywhere in the JSON structure
-const json* MqttDriver::findJsonField(const json& payload, const std::string& targetKey) {
-  if (payload.is_object()) {
-    for (auto it = payload.begin(); it != payload.end(); ++it) {
-      if (it.key() == targetKey) {
-        return &it.value();
-      }
-      else {
-        const json* found = findJsonField(it.value(), targetKey);
-        if (found) return found;
-      }
-    }
-  }
-  else if (payload.is_array()) {
-    for (const auto& el : payload) {
-      const json* found = findJsonField(el, targetKey);
-      if (found) return found;
-    }
-  }
-  return nullptr;
-}
 
 /* Checks if a string corresponds to one of the supported topic types */
 bool MqttDriver::isSupportedTopicType(const std::string& type) {

--- a/mqttSup/src/drvMqtt.h
+++ b/mqttSup/src/drvMqtt.h
@@ -17,6 +17,7 @@
 
 using namespace Autoparam::Convenience;
 using json = nlohmann::json;
+using std::to_string;
 
 static const char* driverName = "MqttDriver";
 
@@ -59,7 +60,6 @@ private:
   DeviceAddress* parseDeviceAddress(std::string const& function, std::string const& arguments);
   DeviceVariable* createDeviceVariable(DeviceVariable* baseVar);
   /* helper methods */
-  static const json* findJsonField(const json& payload, const std::string& targetKey);
   static bool isInteger(const std::string& s, bool isSigned = true);
   static bool isFloat(const std::string& s);
   static bool isSign(char character);


### PR DESCRIPTION
Previously, the module recursively looped and checked key in the iterable. It had a limitation that it could not handle mixed types, root array, and empty key.

JSON Pointer solves this problem because it can address all points in a JSON object whether it is an array or a dictionary.

See also: https://datatracker.ietf.org/doc/html/rfc6901

**Breaking change**

Previous way of referring to JSON field will no longer work. If backward compatibility is desired, calling previous search method first and then applying JSON pointer (at cost of unspecified search speed)

**Exception handling**

There are new possible exceptions coming from to_string, json::at, and json::json_pointer. These errors were already being caught at the catch-all handler at following line, so new handling code was not necessary.

**Other considerations**

 onMessageCb function may benefit from some refactoring, where the values are not always converted into string but into corresponding numeric types, by merging the two steps of identifying if it's JSON and whether the item exists or not, and then matching requested types and converting it into numeric as needed. This optimization was not carried out in this merge request.
