### PR TITLE
parse "true" and "false" for Int/UInt records

### DIFF
--- a/mqttSup/src/drvMqtt.cpp
+++ b/mqttSup/src/drvMqtt.cpp
@@ -275,6 +275,10 @@ void MqttDriver::onMessageCb(Autoparam::Driver* driver, const std::string& topic
     try {
       switch (deviceVar.asynType()) {
         case asynParamInt32:
+          if (isBoolean(val)) {
+            pself->setParam(deviceVar, static_cast<epicsInt32>(val == "true"), asynSuccess);
+            break;
+          }
           if (!isInteger(val)) throw std::invalid_argument("Invalid integer");
           pself->setParam(deviceVar, std::stoi(val), asynSuccess);
           break;
@@ -283,6 +287,10 @@ void MqttDriver::onMessageCb(Autoparam::Driver* driver, const std::string& topic
           pself->setParam(deviceVar, std::stod(val), asynSuccess);
           break;
         case asynParamUInt32Digital:
+          if (isBoolean(val)) {
+            pself->setParam(deviceVar, static_cast<epicsUInt32>(val == "true"), asynSuccess);
+            break;
+          }
           if (!isInteger(val, false)) throw std::invalid_argument("Invalid unsigned integer");
           pself->setParam(deviceVar, static_cast<epicsUInt32>(std::stoul(val)), asynSuccess);
           break;
@@ -374,6 +382,11 @@ bool MqttDriver::isInteger(const std::string& s, bool isSigned) {
     if (!std::isdigit(static_cast<unsigned char>(s[i]))) return false;
   }
   return true;
+}
+
+/* Checks if a string represents a json boolean value */
+bool MqttDriver::isBoolean(const std::string& s) {
+  return (s == "true" || s == "false");
 }
 
 /* Checks if a string represents a float */

--- a/mqttSup/src/drvMqtt.h
+++ b/mqttSup/src/drvMqtt.h
@@ -61,6 +61,7 @@ private:
   /* helper methods */
   static const json* findJsonField(const json& payload, const std::string& targetKey);
   static bool isInteger(const std::string& s, bool isSigned = true);
+  static bool isBoolean(const std::string& s);
   static bool isFloat(const std::string& s);
   static bool isSign(char character);
   static bool isSupportedTopicType(const std::string& type);


### PR DESCRIPTION
I wanted to have this feature added, to reduce extra step needed in database record to parse true/false.

This will reduce work on EPICS side to parse true/false text replies.
No other falsy and truthy variants are handled, because they are not specified in the informative JSON document.

See also: https://datatracker.ietf.org/doc/html/rfc4627#section-2.1