### PR TITLE
Add JSON write support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Local configuration files
 /configure/*.local
+*.Makefile
 
 # iocBoot generated files
 /iocBoot/*ioc*/cdCommands
@@ -30,3 +31,6 @@ O.*/
 *.log
 .*.swp
 .DS_Store
+.cache
+.clangd
+compile_commands.json

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Contributions are welcome - feel free to open issues and pull requests!
 
 - Auto-update of EPICS PVS via `I/O Intr` records;
 - Support for read/write flat MQTT topics (i.e, topics where the payload is a single value or array);
-- Support for reading arbitrarily nested fields from JSON topic payloads;
+- Support for read/write JSON payloads with JSON pointer;
 - Support for MQTT QoS levels;
 - Checks and reject invalid messages (based mostly on type-checking);
 - Auto reconnection of broker;
@@ -58,7 +58,7 @@ device support. For now, the supported interfaces are the following:
      [these](https://github.com/eclipse-paho/paho.mqtt.cpp?tab=readme-ov-file#build-the-paho-c-and-paho-c-libraries-together)
      instructions.
 
-  > Note: AutoparamDriver explicitly requires EPICS >= 7.0, see 
+  > Note: AutoparamDriver explicitly requires EPICS >= 7.0, see
   > [reference](https://github.com/Cosylab/autoparamDriver/blob/main/autoparamDriverSup/src/Makefile#L15). For this reason,
   > this module requires EPICS 7.0 or later to be built and used.
 
@@ -117,9 +117,8 @@ Where:
 - `<FORMAT>` is the format of the payload: `FLAT` or `JSON`.
 - `<TYPE>` is the general type of the expected value [`INT|FLOAT|DIGITAL|STRING|INTARRAY|FLOATARRAY`].
 - `<TOPIC>` is the MQTT topic to which the record will be subscribed/published.
-- `<FIELD>` is the dot-separated path to the field to extract from a JSON payload (e.g. `sensor.temperature`). Arbitrary nesting is supported. Required when `FORMAT` is `JSON`.
 
-> **Note on JSON write support:** Writing to JSON-formatted topics is currently **not supported**. At the moment the driver has no way of knowing the JSON structure expected by the broker ahead of time for write records. For this reason, only `FLAT` format can be used for output records.
+> **Note on JSON support:** A configuration file must be loaded by specifying a .json configuration file using mqttJsonDriverConfigure command
 
 **Important: Due to the pub/sub nature of MQTT, ALL input records are expected to be `I/O Intr`.**
 
@@ -162,6 +161,43 @@ Example:
   iocInit()
 ```
 
+## JSON configuration file
+
+JSON records use a configuration file that specifies how to parse or compose
+a JSON string. The configuration file should have 1 JSON object in its root.
+Each item in this root object refers to an MQTT topic, specified in INP/OUT
+field in a EPICS database record.
+
+```json
+{
+  "readonly_message_root": {
+    "fields": {"VAL": ""}
+  },
+  "readonly_message_dict": {
+    "fields": {"VAL": "/1/path/to/key"}
+  },
+  "write": {
+    "fields": {"VAL": "/0"},
+    "template": [null, {"metadata": "md_content"}]",
+    "writeAddress": "example/write"
+  }
+}
+
+```
+
+In the JSON snippet above, if all three records received a MQTT message with
+string `[3, {"path": {"to": {"key": 2}}}]`, this would be the read result:
+
+- `readonly_message_root`: [3, {"path": {"to": {"key": 2}}}]
+- `readonly_message_dict`: 2
+
+For writing,
+
+- `write` would send a message with content `["payload", {"metadata": "md_content"}]`
+  if it used a string record and write value was "payload". Since writeAddress
+  was specified, it would send the message into topic "example/write". Otherwise,
+  the default write topic is identical to the read topic, "write".
+
 ## Implementation status
 
 Below are the supported interfaces and their implementation status.
@@ -175,10 +211,12 @@ Below are the supported interfaces and their implementation status.
 | Strings             | asynOctetRead/asynOctetWrite           | `FLAT:STRING`               | Read / Write | Supported |
 | Integer Array       | asynInt32ArrayIn/asynInt32ArrayOut     | `FLAT:INTARRAY`             | Read / Write | Supported |
 | Float Array         | asynFloat64ArrayIn/asynFloat64ArrayOut | `FLAT:FLOATARRAY`           | Read / Write | Supported |
-| Integer             | asynInt32                              | `JSON:INT`                  | Read only    | Supported |
-| Float               | asynFloat64                            | `JSON:FLOAT`                | Read only    | Supported |
-| Bit masked          | asynUInt32Digital                      | `JSON:DIGITAL`              | Read only    | Supported |
-| String              | asynOctetRead                          | `JSON:STRING`               | Read only    | Supported |
+| Integer             | asynInt32                              | `JSON:INT`                  | Read / Write | Supported |
+| Float               | asynFloat64                            | `JSON:FLOAT`                | Read / Write | Supported |
+| Bit masked          | asynUInt32Digital                      | `JSON:DIGITAL`              | Read / Write | Supported |
+| String              | asynOctetRead                          | `JSON:STRING`               | Read / Write | Supported |
+| Integer Array       | asynInt32ArrayIn/asynInt32ArrayOut     | `JSON:INTARRAY`             | Read / Write | Supported |
+| Float Array         | asynFloat64ArrayIn/asynFloat64ArrayOut | `JSON:FLOATARRAY`           | Read / Write | Supported |
 
 ## Licensing Terms
 

--- a/iocBoot/ioctest/config.json
+++ b/iocBoot/ioctest/config.json
@@ -1,0 +1,31 @@
+{
+  "epicsMQTT/ci/test/json/int": {
+    "fields": {"VAL": ""},
+    "template": null
+  },
+  "epicsMQTT/ci/test/json/float": {
+    "fields": {"VAL": ""},
+    "template": null
+  },
+  "epicsMQTT/ci/test/json/string": {
+    "fields": {"VAL": ""},
+    "template": null
+  },
+  "epicsMQTT/ci/test/json/intarray": {
+    "fields": {"VAL": ""},
+    "template": null
+  },
+  "epicsMQTT/ci/test/json/floatarray": {
+    "fields": {"VAL": ""},
+    "template": null
+  },
+  "epicsMQTT/ci/test/json/altAddress": {
+    "writeAddress": "epicsMQTT/ci/test/json/altAddress2",
+    "fields": {"VAL": ""},
+    "template": null
+  },
+  "epicsMQTT/ci/test/json/writeTemplate": {
+    "fields": {"VAL": "/2/key"},
+    "template": [0, 1, {"key": null}]
+  }
+}

--- a/iocBoot/ioctest/st.cmd
+++ b/iocBoot/ioctest/st.cmd
@@ -20,7 +20,7 @@ epicsEnvSet("P", "mqtt:test:")
 epicsEnvSet("R", "")
 epicsEnvSet("TOPIC_ROOT", "$(MQTT_TEST_TOPIC_ROOT=epicsMQTT/ci/test)")
 
-mqttDriverConfigure($(PORT), $(BROKER_URL), $(CLIENT_ID), $(QOS))
+mqttJsonDriverConfigure($(PORT), $(BROKER_URL), $(CLIENT_ID), $(QOS), "${TOP}/iocBoot/ioctest/config.json")
 
 ## Load test records
 dbLoadRecords("db/mqttTest.db", "P=$(P),R=$(R),PORT=$(PORT),TOPIC_ROOT=$(TOPIC_ROOT)")

--- a/mqttSup/src/drvMqtt.cpp
+++ b/mqttSup/src/drvMqtt.cpp
@@ -256,13 +256,7 @@ void MqttDriver::onMessageCb(Autoparam::Driver* driver, const std::string& topic
     if (addr.format == MqttTopicAddr::JSON) {
       try {
         json root = json::parse(payload);
-        const json* fieldAddr = findJsonField(root, addr.jsonField);
-        if (!fieldAddr || fieldAddr->is_null())
-          throw std::invalid_argument("JSON field not found: " + addr.jsonField);
-        if (fieldAddr->is_string())
-          val = fieldAddr->get<std::string>();
-        else
-          val = fieldAddr->dump();
+        val = to_string(root.at(json::json_pointer(addr.jsonField)));
       }
       catch (const std::exception& e) {
         asynPrint(pself->pasynUserSelf, ASYN_TRACE_ERROR,
@@ -335,28 +329,6 @@ void MqttDriver::onMessageCb(Autoparam::Driver* driver, const std::string& topic
 }
 //#############################################################################################
 // Helper methods
-
-// Recursively search for a key anywhere in the JSON structure
-const json* MqttDriver::findJsonField(const json& payload, const std::string& targetKey) {
-  if (payload.is_object()) {
-    for (auto it = payload.begin(); it != payload.end(); ++it) {
-      if (it.key() == targetKey) {
-        return &it.value();
-      }
-      else {
-        const json* found = findJsonField(it.value(), targetKey);
-        if (found) return found;
-      }
-    }
-  }
-  else if (payload.is_array()) {
-    for (const auto& el : payload) {
-      const json* found = findJsonField(el, targetKey);
-      if (found) return found;
-    }
-  }
-  return nullptr;
-}
 
 /* Checks if a string corresponds to one of the supported topic types */
 bool MqttDriver::isSupportedTopicType(const std::string& type) {

--- a/mqttSup/src/drvMqtt.cpp
+++ b/mqttSup/src/drvMqtt.cpp
@@ -44,13 +44,7 @@ const std::unordered_set<std::string> MqttDriver::supportedTopicTypes = {
 bool MqttTopicAddr::operator==(DeviceAddress const& comparedAddr) const {
   const MqttTopicAddr& cmp = static_cast<const MqttTopicAddr&>(comparedAddr);
   if (format != cmp.format) return false;
-  switch (format) {
-    case FLAT:
-      return topicName == cmp.topicName;
-    case JSON:
-      return topicName == cmp.topicName && jsonField == cmp.jsonField;
-  }
-  return false;
+  return topicName == cmp.topicName;
 }
 
 DeviceAddress* MqttDriver::parseDeviceAddress(std::string const& function, std::string const& arguments) {
@@ -63,44 +57,26 @@ DeviceAddress* MqttDriver::parseDeviceAddress(std::string const& function, std::
   }
   auto colonPos = function.find(':');
   std::string prefix = function.substr(0, colonPos);
-  if (prefix == FLAT_FUNC_PREFIX) {
-    std::string topicName = arguments;
-    if (!isValidTopicName(topicName)) {
-      fprintf(stderr, "%s::%s: Invalid topic name: %s\n", driverName, functionName, topicName.c_str());
-      delete addr;
-      return nullptr;
-    }
-    addr->format = MqttTopicAddr::FLAT;
-    addr->topicName = topicName;
-  }
-  else if (prefix == JSON_FUNC_PREFIX) {
-    auto spacePos = arguments.find(' ');
-    if (spacePos == std::string::npos) {
-      fprintf(stderr, "%s::%s: JSON field not specified: %s\n", driverName, functionName, arguments.c_str());
-      delete addr;
-      return nullptr;
-    }
-    if (spacePos + 1 >= arguments.size()) {
-      fprintf(stderr, "%s::%s: JSON field is empty: %s\n", driverName, functionName, arguments.c_str());
-      delete addr;
-      return nullptr;
-    }
-    std::string topicName = arguments.substr(0, spacePos);
-    if (!isValidTopicName(topicName)) {
-      fprintf(stderr, "%s::%s: Invalid topic name: %s\n", driverName, functionName, topicName.c_str());
-      delete addr;
-      return nullptr;
-    }
-    std::string jsonField = arguments.substr(spacePos + 1, arguments.size());
-    addr->format = MqttTopicAddr::JSON;
-    addr->topicName = topicName;
-    addr->jsonField = jsonField;
-  }
-  else {
+  std::string topicName = arguments;
+  if (!isValidTopicName(topicName)) {
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s: Invalid topic name: %s", driverName, functionName, topicName.c_str());
     delete addr;
     return nullptr;
   }
-
+  addr->topicName = topicName;
+  if (prefix == FLAT_FUNC_PREFIX) {
+    addr->format = MqttTopicAddr::FLAT;
+  } else if (prefix == JSON_FUNC_PREFIX) {
+    if (!jsonConfig.contains(arguments)) {
+      asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s: Json config file does not include %s", driverName, functionName, arguments.c_str());
+      delete addr;
+      return nullptr;
+    }
+    addr->format = MqttTopicAddr::JSON;
+  } else {
+    delete addr;
+    return nullptr;
+  }
   return addr;
 }
 
@@ -288,13 +264,14 @@ void MqttDriver::onMessageCb(Autoparam::Driver* driver, const std::string& topic
       continue;
     if (addr.format == MqttTopicAddr::JSON) {
       try {
+        std::string value_pointer = pself->jsonConfig[topic]["/fields/VAL"_json_pointer];
         json root = json::parse(payload);
-        val = to_string(root.at(json::json_pointer(addr.jsonField)));
+        val = to_string(root[json::json_pointer(value_pointer)]);
       }
       catch (const std::exception& e) {
         asynPrint(pself->pasynUserSelf, ASYN_TRACE_ERROR,
-          "%s::%s: Failed to parse JSON payload for topic '%s', field '%s': %s\n",
-          driverName, functionName, topic.c_str(), addr.jsonField.c_str(), e.what());
+          "%s::%s: Failed to parse JSON payload for topic '%s' : %s\n",
+          driverName, functionName, topic.c_str(), e.what());
         continue;
       }
     }

--- a/mqttSup/src/drvMqtt.cpp
+++ b/mqttSup/src/drvMqtt.cpp
@@ -550,6 +550,23 @@ asynStatus MqttDriver::checkAndParseFloatArray(const std::string& s, std::vector
   return asynSuccess;
 }
 
+/* Shared JSON compose helper method. Returns a string to be sent via MQTT */
+std::string MqttDriver::composeJsonWrite(MqttDriver* driver, std::string& topicName, json value) {
+  json data = driver->jsonConfig[topicName]["template"];
+  try {
+    auto& fields = driver->jsonConfig[topicName]["fields"];
+    if (fields.contains("VAL")) {
+      data[json::json_pointer(fields["VAL"])] = value;
+    }
+  } catch (const json::exception& exc) {
+    asynPrint(driver->pasynUserSelf, ASYN_TRACE_ERROR, "Failed to compose Json write for %s\n", topicName.c_str());
+    throw;
+  }
+  auto text = data.dump();
+  asynPrint(driver->pasynUserSelf, ASYN_TRACE_FLOW, "Composed data with content: %s\n", text.c_str());
+  return text;
+}
+
 //#############################################################################################
 // IO function definitions
 
@@ -566,8 +583,8 @@ WriteResult MqttDriver::integerWrite(DeviceVariable& deviceVar, epicsInt32 value
       status = asynSuccess;
     }
     else if (addr.format == MqttTopicAddr::TopicFormat::JSON) {
-      // TODO: implement JSON support for integer values
-      throw std::logic_error("JSON support not implemented");
+      auto text = composeJsonWrite(driver, topicName, value);
+      driver->mqttClient.publish(addr.topicName, text);
     }
   }
   catch (const std::exception& exc) {
@@ -608,8 +625,8 @@ WriteResult MqttDriver::digitalWrite(DeviceVariable& deviceVar, epicsUInt32 cons
       status = asynSuccess;
     }
     else if (addr.format == MqttTopicAddr::TopicFormat::JSON) {
-      // TODO: implement JSON support for digital values
-      throw std::logic_error("JSON support not implemented");
+      auto text = composeJsonWrite(driver, topicName, value);
+      driver->mqttClient.publish(addr.topicName, text);
     }
   }
   catch (const std::exception& exc) {
@@ -635,8 +652,8 @@ WriteResult MqttDriver::floatWrite(DeviceVariable& deviceVar, epicsFloat64 value
       status = asynSuccess;
     }
     else if (addr.format == MqttTopicAddr::TopicFormat::JSON) {
-      // TODO: implement JSON support for float values
-      throw std::logic_error("JSON support not implemented");
+      auto text = composeJsonWrite(driver, topicName, value);
+      driver->mqttClient.publish(addr.topicName, text);
     }
   }
   catch (const std::exception& exc) {
@@ -658,10 +675,9 @@ WriteResult MqttDriver::arrayWrite(DeviceVariable& deviceVar, Array<epicsDataTyp
   std::string topicName = addr.topicName;
   MqttDriver* driver = static_cast<MqttTopicVariable&>(deviceVar).driver;
   try {
+    const epicsDataType* arrayData = reinterpret_cast<const epicsDataType*>(value.data());
+    size_t count = value.size();
     if (addr.format == MqttTopicAddr::TopicFormat::FLAT) {
-      const epicsDataType* arrayData = reinterpret_cast<const epicsDataType*>(value.data());
-      size_t count = value.size();
-
       std::ostringstream oss;
       for (size_t i = 0; i < count; ++i) {
         if (i > 0) oss << ",";
@@ -671,8 +687,12 @@ WriteResult MqttDriver::arrayWrite(DeviceVariable& deviceVar, Array<epicsDataTyp
       status = asynSuccess;
     }
     else if (addr.format == MqttTopicAddr::TopicFormat::JSON) {
-      // TODO: implement JSON support for array values
-      throw std::logic_error("JSON support not implemented");
+      json data = json::array();
+      for (size_t i = 0; i < count; ++i) {
+        data.push_back(arrayData[i]);
+      }
+      auto text = composeJsonWrite(driver, topicName, data);
+      driver->mqttClient.publish(addr.topicName, text);
     }
   }
   catch (const std::exception& exc) {
@@ -692,17 +712,15 @@ WriteResult MqttDriver::stringWrite(DeviceVariable& deviceVar, Octet const& valu
   MqttTopicAddr const& addr = static_cast<MqttTopicAddr const&>(deviceVar.address());
   std::string topicName = addr.topicName;
   MqttDriver* driver = static_cast<MqttTopicVariable&>(deviceVar).driver;
+  std::vector<char> stringData(value.maxSize());
+  value.writeTo(stringData.data(), stringData.size());
   try {
     if (addr.format == MqttTopicAddr::TopicFormat::FLAT) {
-      std::vector<char> stringData(value.maxSize());
-      if (value.writeTo(stringData.data(), stringData.size())) {
-        driver->mqttClient.publish(addr.topicName, stringData.data());
-        status = asynSuccess;
-      }
-    }
-    else if (addr.format == MqttTopicAddr::TopicFormat::JSON) {
-      // TODO: implement JSON support for string values
-      throw std::logic_error("JSON support not implemented");
+      driver->mqttClient.publish(addr.topicName, stringData.data());
+      status = asynSuccess;
+    } else if (addr.format == MqttTopicAddr::TopicFormat::JSON) {
+      auto text = composeJsonWrite(driver, topicName, stringData.data());
+      driver->mqttClient.publish(addr.topicName, text);
     }
   }
   catch (const std::exception& exc) {

--- a/mqttSup/src/drvMqtt.cpp
+++ b/mqttSup/src/drvMqtt.cpp
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 André Favoto
 
 #include "drvMqtt.h"
+#include "asynDriver.h"
 #include "mqttClient.h"
+#include <fstream>
 
 // Supported type definitions
 
@@ -176,6 +178,37 @@ MqttDriver::MqttDriver(const char* portName, const char* brokerUrl, const char* 
   registerHandlers<Array<epicsInt32>>(JSON_INTARRAY_FUNC_STR, NULL, arrayWrite, NULL);
   registerHandlers<Array<epicsFloat64>>(JSON_FLOATARRAY_FUNC_STR, NULL, arrayWrite, NULL);
 }
+
+/* MqttDriver constructor with json configFile parsing */
+MqttDriver::MqttDriver(const char* portName, const char* brokerUrl, const char* mqttClientID, const int qos, const char* configFile)
+  : MqttDriver(portName, brokerUrl, mqttClientID, qos)
+{
+  std::ifstream file(configFile, std::ios::in);
+  if (!file.is_open()) {
+    throw std::runtime_error("Unable to open JSON config file: " + std::string(configFile));
+  }
+  json content = json::parse(file);
+
+  // ensure that json config file has the expected structure
+  for (auto [topicName, topic]: content.items()) {
+    if (!topic.is_object()) {
+      throw std::runtime_error("JSON config for MQTT topic " + topicName + " could not be parsed as json object");
+    }
+    if (!topic["fields"].is_object()) {
+      throw std::runtime_error("JSON field config for " + topicName + " is not a JSON object");
+    }
+    if (!topic.contains("template")) continue;
+    // if template exists, verify that every field can be mapped into the field.
+    for (auto [fieldName, field]: topic["fields"].items()) {
+      if (!topic["template"].contains(json::json_pointer(field))) {
+        throw std::runtime_error("JSON template for " + topicName + " does not include " + fieldName);
+      }
+    }
+    asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "Identified JSON configuration for %s\n", topicName.c_str());
+  }
+  jsonConfig = content;
+}
+
 /* Class destructor
    - Disconnects from the broker and cleans session
 */
@@ -710,36 +743,51 @@ extern "C" {
     new MqttDriver(portName, brokerUrl, mqttClientID, qos);
     return(asynSuccess);
   }
+  int mqttJsonDriverConfigure(const char* portName, const char* brokerUrl, const char* mqttClientID, const int qos, const char* configFile) {
+    new MqttDriver(portName, brokerUrl, mqttClientID, qos, configFile);
+    return(asynSuccess);
+  }
   static const int numArgs = 4;
   static const iocshArg initArg0 = { "portName", iocshArgString };
   static const iocshArg initArg1 = { "brokerUrl", iocshArgString };
   static const iocshArg initArg2 = { "mqttClientID", iocshArgString };
   static const iocshArg initArg3 = { "qos", iocshArgInt };
+  static const iocshArg initArg4 = { "configFile", iocshArgString };
   static const iocshArg* const initArgs[] = {
       &initArg0,
       &initArg1,
       &initArg2,
-      &initArg3
+      &initArg3,
+      &initArg4
   };
   static const char* usage =
     "MqttDriverConfigure(portName, brokerUrl, mqttClientID, qos)\n"
     "  portName: Asyn port name to be used\n"
     "  brokerUrl: Broker IP or hostname (e.g: mqtt://localhost:1883)\n"
     "  mqttClientID: ClientID to be used - must be unique\n"
-    "  qos: Desired quality of service (QoS) for the connection [0|1|2]\n";
+    "  qos: Desired quality of service (QoS) for the connection [0|1|2]\n"
+    "  [configFile]: path to JSON configuration file";
 
   //#############################################################################################
   static const iocshFuncDef initFuncDef = { "mqttDriverConfigure", numArgs, initArgs, usage };
+  static const iocshFuncDef jsonInitFuncDef = { "mqttJsonDriverConfigure", 5, initArgs, usage };
 
   //#############################################################################################
   static void initCallFunc(const iocshArgBuf* args) {
     mqttDriverConfigure(args[0].sval, args[1].sval, args[2].sval, args[3].ival);
+  }
+  static void jsonInitCallFunc(const iocshArgBuf* args) {
+    mqttJsonDriverConfigure(args[0].sval, args[1].sval, args[2].sval, args[3].ival, args[4].sval);
   }
 
   //#############################################################################################
   void mqttDriverRegister(void) {
     iocshRegister(&initFuncDef, initCallFunc);
   }
+  void mqttJsonDriverRegister(void) {
+    iocshRegister(&jsonInitFuncDef, jsonInitCallFunc);
+  }
 
   epicsExportRegistrar(mqttDriverRegister);
+  epicsExportRegistrar(mqttJsonDriverRegister);
 }

--- a/mqttSup/src/drvMqtt.cpp
+++ b/mqttSup/src/drvMqtt.cpp
@@ -49,34 +49,35 @@ bool MqttTopicAddr::operator==(DeviceAddress const& comparedAddr) const {
 
 DeviceAddress* MqttDriver::parseDeviceAddress(std::string const& function, std::string const& arguments) {
   const char* functionName = __FUNCTION__;
-  MqttTopicAddr* addr = new MqttTopicAddr;
-  if (!isSupportedTopicType(function)) {
-    fprintf(stderr, "%s::%s: Invalid topic type: %s\n", driverName, functionName, function.c_str());
-    delete addr;
-    return nullptr;
-  }
+  MqttTopicAddr::TopicFormat format;
+  std::string topicName = arguments;
   auto colonPos = function.find(':');
   std::string prefix = function.substr(0, colonPos);
-  std::string topicName = arguments;
-  if (!isValidTopicName(topicName)) {
-    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s: Invalid topic name: %s", driverName, functionName, topicName.c_str());
-    delete addr;
+
+  if (!isSupportedTopicType(function)) {
+    fprintf(stderr, "%s::%s: Invalid topic type: %s\n", driverName, functionName, function.c_str());
     return nullptr;
   }
-  addr->topicName = topicName;
+  if (!isValidTopicName(topicName)) {
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s: Invalid topic name: %s", driverName, functionName, topicName.c_str());
+    return nullptr;
+  }
   if (prefix == FLAT_FUNC_PREFIX) {
-    addr->format = MqttTopicAddr::FLAT;
+    format = MqttTopicAddr::FLAT;
   } else if (prefix == JSON_FUNC_PREFIX) {
     if (!jsonConfig.contains(arguments)) {
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s: Json config file does not include %s", driverName, functionName, arguments.c_str());
-      delete addr;
       return nullptr;
     }
-    addr->format = MqttTopicAddr::JSON;
+    format = MqttTopicAddr::JSON;
   } else {
-    delete addr;
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s: Unknown function type '%s', only JSON or FLAT is supported.", driverName, functionName, function.c_str());
     return nullptr;
   }
+
+  MqttTopicAddr* addr = new MqttTopicAddr;
+  addr->topicName = topicName;
+  addr->format = format;
   return addr;
 }
 

--- a/mqttSup/src/drvMqtt.cpp
+++ b/mqttSup/src/drvMqtt.cpp
@@ -53,6 +53,8 @@ DeviceAddress* MqttDriver::parseDeviceAddress(std::string const& function, std::
   std::string topicName = arguments;
   auto colonPos = function.find(':');
   std::string prefix = function.substr(0, colonPos);
+  std::string writeAddress = topicName;
+  bool writable = true;
 
   if (!isSupportedTopicType(function)) {
     fprintf(stderr, "%s::%s: Invalid topic type: %s\n", driverName, functionName, function.c_str());
@@ -69,6 +71,11 @@ DeviceAddress* MqttDriver::parseDeviceAddress(std::string const& function, std::
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s: Json config file does not include %s", driverName, functionName, arguments.c_str());
       return nullptr;
     }
+    if (!this->jsonConfig[topicName].contains("template")) {
+      writable = false;
+    } else {
+      writeAddress = this->jsonConfig[topicName].value("writeAddress", topicName);
+    }
     format = MqttTopicAddr::JSON;
   } else {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s: Unknown function type '%s', only JSON or FLAT is supported.", driverName, functionName, function.c_str());
@@ -77,7 +84,9 @@ DeviceAddress* MqttDriver::parseDeviceAddress(std::string const& function, std::
 
   MqttTopicAddr* addr = new MqttTopicAddr;
   addr->topicName = topicName;
+  addr->writeAddress = writeAddress;
   addr->format = format;
+  addr->writeable = writable;
   return addr;
 }
 
@@ -171,14 +180,23 @@ MqttDriver::MqttDriver(const char* portName, const char* brokerUrl, const char* 
     if (!topic.is_object()) {
       throw std::runtime_error("JSON config for MQTT topic " + topicName + " could not be parsed as json object");
     }
-    if (!topic["fields"].is_object()) {
-      throw std::runtime_error("JSON field config for " + topicName + " is not a JSON object");
+    if (!topic.contains("fields") || !topic["fields"].is_object()) {
+      throw std::runtime_error("JSON field config for " + topicName + " is missing or is not a JSON object");
     }
-    if (!topic.contains("template")) continue;
-    // if template exists, verify that every field can be mapped into the field.
-    for (auto [fieldName, field]: topic["fields"].items()) {
-      if (!topic["template"].contains(json::json_pointer(field))) {
-        throw std::runtime_error("JSON template for " + topicName + " does not include " + fieldName);
+    if (topic.contains("writeAddress")) {
+      if (!topic["writeAddress"].is_string()) {
+        throw std::runtime_error("Write address for topic " + topicName + " was not a string");
+      }
+    } else {
+      // fall back (read and write into the same address)
+      topic["writeAddress"] = topicName;
+    }
+    if (topic.contains("template")) {
+      // if template exists, verify that every field can be mapped into the field.
+      for (auto [fieldName, field]: topic["fields"].items()) {
+        if (!topic["template"].contains(json::json_pointer(field))) {
+          throw std::runtime_error("JSON template for " + topicName + " does not include " + fieldName);
+        }
       }
     }
     asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "Identified JSON configuration for %s\n", topicName.c_str());
@@ -265,6 +283,7 @@ void MqttDriver::onMessageCb(Autoparam::Driver* driver, const std::string& topic
       continue;
     if (addr.format == MqttTopicAddr::JSON) {
       try {
+        if (!pself->jsonConfig.contains(topic)) continue;
         std::string value_pointer = pself->jsonConfig[topic]["/fields/VAL"_json_pointer];
         json root = json::parse(payload);
         val = to_string(root[json::json_pointer(value_pointer)]);
@@ -577,14 +596,21 @@ WriteResult MqttDriver::integerWrite(DeviceVariable& deviceVar, epicsInt32 value
   MqttTopicAddr const& addr = static_cast<MqttTopicAddr const&>(deviceVar.address());
   std::string topicName = addr.topicName;
   MqttDriver* driver = static_cast<MqttTopicVariable&>(deviceVar).driver;
+  if (!addr.writeable) {
+    result.status = asynError;
+    asynPrint(driver->pasynUserSelf, ASYN_TRACE_ERROR,
+      "%s::%s: Write was requested for topic '%s' which is not writeable)\n",
+      driverName, functionName, topicName.c_str());
+    return result;
+  }
   try {
     if (addr.format == MqttTopicAddr::TopicFormat::FLAT) {
-      driver->mqttClient.publish(addr.topicName, std::to_string(value));
+      driver->mqttClient.publish(addr.writeAddress, std::to_string(value));
       status = asynSuccess;
     }
     else if (addr.format == MqttTopicAddr::TopicFormat::JSON) {
       auto text = composeJsonWrite(driver, topicName, value);
-      driver->mqttClient.publish(addr.topicName, text);
+      driver->mqttClient.publish(addr.writeAddress, text);
     }
   }
   catch (const std::exception& exc) {
@@ -605,6 +631,13 @@ WriteResult MqttDriver::digitalWrite(DeviceVariable& deviceVar, epicsUInt32 cons
   std::string topicName = addr.topicName;
   MqttDriver* driver = static_cast<MqttTopicVariable&>(deviceVar).driver;
   epicsUInt32 outVal = value;
+  if (!addr.writeable) {
+    result.status = asynError;
+    asynPrint(driver->pasynUserSelf, ASYN_TRACE_ERROR,
+      "%s::%s: Write was requested for topic '%s' which is not writeable)\n",
+      driverName, functionName, topicName.c_str());
+    return result;
+  }
   try {
     if (addr.format == MqttTopicAddr::TopicFormat::FLAT) {
       if (mask != 0xFFFFFFFF) {
@@ -621,12 +654,12 @@ WriteResult MqttDriver::digitalWrite(DeviceVariable& deviceVar, epicsUInt32 cons
         auxVal &= (value | ~mask);
         outVal = auxVal;
       }
-      driver->mqttClient.publish(addr.topicName, std::to_string(outVal));
+      driver->mqttClient.publish(addr.writeAddress, std::to_string(outVal));
       status = asynSuccess;
     }
     else if (addr.format == MqttTopicAddr::TopicFormat::JSON) {
       auto text = composeJsonWrite(driver, topicName, value);
-      driver->mqttClient.publish(addr.topicName, text);
+      driver->mqttClient.publish(addr.writeAddress, text);
     }
   }
   catch (const std::exception& exc) {
@@ -646,14 +679,21 @@ WriteResult MqttDriver::floatWrite(DeviceVariable& deviceVar, epicsFloat64 value
   MqttTopicAddr const& addr = static_cast<MqttTopicAddr const&>(deviceVar.address());
   std::string topicName = addr.topicName;
   MqttDriver* driver = static_cast<MqttTopicVariable&>(deviceVar).driver;
+  if (!addr.writeable) {
+    result.status = asynError;
+    asynPrint(driver->pasynUserSelf, ASYN_TRACE_ERROR,
+      "%s::%s: Write was requested for topic '%s' which is not writeable)\n",
+      driverName, functionName, topicName.c_str());
+    return result;
+  }
   try {
     if (addr.format == MqttTopicAddr::TopicFormat::FLAT) {
-      driver->mqttClient.publish(addr.topicName, std::to_string(value));
+      driver->mqttClient.publish(addr.writeAddress, std::to_string(value));
       status = asynSuccess;
     }
     else if (addr.format == MqttTopicAddr::TopicFormat::JSON) {
       auto text = composeJsonWrite(driver, topicName, value);
-      driver->mqttClient.publish(addr.topicName, text);
+      driver->mqttClient.publish(addr.writeAddress, text);
     }
   }
   catch (const std::exception& exc) {
@@ -674,6 +714,13 @@ WriteResult MqttDriver::arrayWrite(DeviceVariable& deviceVar, Array<epicsDataTyp
   MqttTopicAddr const& addr = static_cast<MqttTopicAddr const&>(deviceVar.address());
   std::string topicName = addr.topicName;
   MqttDriver* driver = static_cast<MqttTopicVariable&>(deviceVar).driver;
+  if (!addr.writeable) {
+    result.status = asynError;
+    asynPrint(driver->pasynUserSelf, ASYN_TRACE_ERROR,
+      "%s::%s: Write was requested for topic '%s' which is not writeable)\n",
+      driverName, functionName, topicName.c_str());
+    return result;
+  }
   try {
     const epicsDataType* arrayData = reinterpret_cast<const epicsDataType*>(value.data());
     size_t count = value.size();
@@ -683,7 +730,7 @@ WriteResult MqttDriver::arrayWrite(DeviceVariable& deviceVar, Array<epicsDataTyp
         if (i > 0) oss << ",";
         oss << arrayData[i];
       }
-      driver->mqttClient.publish(topicName, oss.str());
+      driver->mqttClient.publish(addr.writeAddress, oss.str());
       status = asynSuccess;
     }
     else if (addr.format == MqttTopicAddr::TopicFormat::JSON) {
@@ -692,7 +739,7 @@ WriteResult MqttDriver::arrayWrite(DeviceVariable& deviceVar, Array<epicsDataTyp
         data.push_back(arrayData[i]);
       }
       auto text = composeJsonWrite(driver, topicName, data);
-      driver->mqttClient.publish(addr.topicName, text);
+      driver->mqttClient.publish(addr.writeAddress, text);
     }
   }
   catch (const std::exception& exc) {
@@ -714,13 +761,20 @@ WriteResult MqttDriver::stringWrite(DeviceVariable& deviceVar, Octet const& valu
   MqttDriver* driver = static_cast<MqttTopicVariable&>(deviceVar).driver;
   std::vector<char> stringData(value.maxSize());
   value.writeTo(stringData.data(), stringData.size());
+  if (!addr.writeable) {
+    result.status = asynError;
+    asynPrint(driver->pasynUserSelf, ASYN_TRACE_ERROR,
+      "%s::%s: Write was requested for topic '%s' which is not writeable)\n",
+      driverName, functionName, topicName.c_str());
+    return result;
+  }
   try {
     if (addr.format == MqttTopicAddr::TopicFormat::FLAT) {
-      driver->mqttClient.publish(addr.topicName, stringData.data());
+      driver->mqttClient.publish(addr.writeAddress, stringData.data());
       status = asynSuccess;
     } else if (addr.format == MqttTopicAddr::TopicFormat::JSON) {
       auto text = composeJsonWrite(driver, topicName, stringData.data());
-      driver->mqttClient.publish(addr.topicName, text);
+      driver->mqttClient.publish(addr.writeAddress, text);
     }
   }
   catch (const std::exception& exc) {

--- a/mqttSup/src/drvMqtt.dbd
+++ b/mqttSup/src/drvMqtt.dbd
@@ -1,1 +1,2 @@
 registrar("mqttDriverRegister")
+registrar("mqttJsonDriverRegister")

--- a/mqttSup/src/drvMqtt.h
+++ b/mqttSup/src/drvMqtt.h
@@ -78,7 +78,6 @@ public:
 
   TopicFormat format;
   std::string topicName;
-  std::string jsonField;
   epicsUInt32 mask = 0xFFFFFFFF;
   bool operator==(DeviceAddress const& comparedAddr) const;
 };

--- a/mqttSup/src/drvMqtt.h
+++ b/mqttSup/src/drvMqtt.h
@@ -25,6 +25,7 @@ class MqttDriver : public Autoparam::Driver {
 public:
   /* Constructor */
   MqttDriver(const char* portName, const char* mqttBrokerAddr, const char* mqttClientID, const int qos);
+  MqttDriver(const char* portName, const char* mqttBrokerAddr, const char* mqttClientID, const int qos, const char* configFile);
   /* Destructor */
   ~MqttDriver();
   /*! \brief Supported types for MQTT topics.
@@ -68,6 +69,7 @@ private:
   static bool isValidTopicName(const std::string& topicName);
   static asynStatus checkAndParseIntArray(const std::string& s, std::vector<epicsInt32>& out);
   static asynStatus checkAndParseFloatArray(const std::string& s, std::vector<epicsFloat64>& out);
+  json jsonConfig;
 };
 
 class MqttTopicAddr : public DeviceAddress {

--- a/mqttSup/src/drvMqtt.h
+++ b/mqttSup/src/drvMqtt.h
@@ -79,8 +79,10 @@ public:
 
   TopicFormat format;
   std::string topicName;
+  std::string writeAddress;
   epicsUInt32 mask = 0xFFFFFFFF;
   bool operator==(DeviceAddress const& comparedAddr) const;
+  bool writeable;
 };
 
 class MqttTopicVariable : public DeviceVariable {

--- a/mqttSup/src/drvMqtt.h
+++ b/mqttSup/src/drvMqtt.h
@@ -61,6 +61,7 @@ private:
   DeviceAddress* parseDeviceAddress(std::string const& function, std::string const& arguments);
   DeviceVariable* createDeviceVariable(DeviceVariable* baseVar);
   /* helper methods */
+  static std::string composeJsonWrite(MqttDriver* deviceVar, std::string& topicName, json value);
   static bool isInteger(const std::string& s, bool isSigned = true);
   static bool isBoolean(const std::string& s);
   static bool isFloat(const std::string& s);

--- a/mqttSup/src/drvMqtt.h
+++ b/mqttSup/src/drvMqtt.h
@@ -17,6 +17,7 @@
 
 using namespace Autoparam::Convenience;
 using json = nlohmann::json;
+using std::to_string;
 
 static const char* driverName = "MqttDriver";
 
@@ -59,7 +60,6 @@ private:
   DeviceAddress* parseDeviceAddress(std::string const& function, std::string const& arguments);
   DeviceVariable* createDeviceVariable(DeviceVariable* baseVar);
   /* helper methods */
-  static const json* findJsonField(const json& payload, const std::string& targetKey);
   static bool isInteger(const std::string& s, bool isSigned = true);
   static bool isBoolean(const std::string& s);
   static bool isFloat(const std::string& s);

--- a/testApp/Db/mqttTest.db
+++ b/testApp/Db/mqttTest.db
@@ -70,3 +70,102 @@ record(aao, "$(P)$(R)FloatArrayOutput") {
 	field(NELM, "16")
 	field(OUT, "@asyn($(PORT)) FLAT:FLOATARRAY $(TOPIC_ROOT)/floatarray")
 }
+
+record(ai, "$(P)$(R)JsonInt32Input") {
+	field(DESC, "CI Int32 Input")
+	field(DTYP, "asynInt32")
+	field(SCAN, "I/O Intr")
+	field(INP, "@asyn($(PORT)) JSON:INT $(TOPIC_ROOT)/json/int")
+}
+
+record(ao, "$(P)$(R)JsonInt32Output") {
+	field(DESC, "CI Int32 Output")
+	field(DTYP, "asynInt32")
+	field(OUT, "@asyn($(PORT)) JSON:INT $(TOPIC_ROOT)/json/int")
+}
+
+record(ai, "$(P)$(R)JsonFloat64Input") {
+	field(DESC, "CI Float64 Input")
+	field(DTYP, "asynFloat64")
+	field(SCAN, "I/O Intr")
+	field(INP, "@asyn($(PORT)) JSON:FLOAT $(TOPIC_ROOT)/json/float")
+}
+
+record(ao, "$(P)$(R)JsonFloat64Output") {
+	field(DESC, "CI Float64 Output")
+	field(DTYP, "asynFloat64")
+	field(OUT, "@asyn($(PORT)) JSON:FLOAT $(TOPIC_ROOT)/json/float")
+}
+
+record(stringin, "$(P)$(R)JsonStringInput") {
+	field(DESC, "CI String Input")
+	field(DTYP, "asynOctetRead")
+	field(SCAN, "I/O Intr")
+	field(INP, "@asyn($(PORT)) JSON:STRING $(TOPIC_ROOT)/json/string")
+}
+
+record(stringout, "$(P)$(R)JsonStringOutput") {
+	field(DESC, "CI String Output")
+	field(DTYP, "asynOctetWrite")
+	field(OUT, "@asyn($(PORT)) JSON:STRING $(TOPIC_ROOT)/json/string")
+}
+
+record(aai, "$(P)$(R)JsonIntArrayInput") {
+	field(DESC, "CI Int Array Input")
+	field(DTYP, "asynInt32ArrayIn")
+	field(SCAN, "I/O Intr")
+	field(FTVL, "LONG")
+	field(NELM, "16")
+	field(INP, "@asyn($(PORT)) JSON:INTARRAY $(TOPIC_ROOT)/json/intarray")
+}
+
+record(aao, "$(P)$(R)JsonIntArrayOutput") {
+	field(DESC, "CI Int Array Output")
+	field(DTYP, "asynInt32ArrayOut")
+	field(FTVL, "LONG")
+	field(NELM, "16")
+	field(OUT, "@asyn($(PORT)) JSON:INTARRAY $(TOPIC_ROOT)/json/intarray")
+}
+
+record(aai, "$(P)$(R)JsonFloatArrayInput") {
+	field(DESC, "CI Float Array Input")
+	field(DTYP, "asynFloat64ArrayIn")
+	field(SCAN, "I/O Intr")
+	field(FTVL, "DOUBLE")
+	field(NELM, "16")
+	field(INP, "@asyn($(PORT)) JSON:FLOATARRAY $(TOPIC_ROOT)/json/floatarray")
+}
+
+record(aao, "$(P)$(R)JsonFloatArrayOutput") {
+	field(DESC, "CI Float Array Output")
+	field(DTYP, "asynFloat64ArrayOut")
+	field(FTVL, "DOUBLE")
+	field(NELM, "16")
+	field(OUT, "@asyn($(PORT)) JSON:FLOATARRAY $(TOPIC_ROOT)/json/floatarray")
+}
+
+record(ai, "$(P)$(R)AltAddressInput") {
+	field(DESC, "CI Alt Address Input")
+	field(DTYP, "asynInt32")
+	field(SCAN, "I/O Intr")
+	field(INP, "@asyn($(PORT)) FLAT:INT $(TOPIC_ROOT)/json/altAddress2")
+}
+
+record(ao, "$(P)$(R)JsonAltAddressOutput") {
+	field(DESC, "CI Alt Address Output")
+	field(DTYP, "asynInt32")
+	field(OUT, "@asyn($(PORT)) JSON:INT $(TOPIC_ROOT)/json/altAddress")
+}
+
+record(ai, "$(P)$(R)JsonAltAddressInput") {
+	field(DESC, "CI Template Input")
+	field(DTYP, "asynInt32")
+	field(SCAN, "I/O Intr")
+	field(INP, "@asyn($(PORT)) JSON:INT $(TOPIC_ROOT)/json/writeTemplate")
+}
+
+record(ao, "$(P)$(R)JsonAltAddressOutput") {
+	field(DESC, "CI Template Output")
+	field(DTYP, "asynInt32")
+	field(OUT, "@asyn($(PORT)) JSON:INT $(TOPIC_ROOT)/json/writeTemplate")
+}

--- a/tests/test_mqtt_roundtrip.py
+++ b/tests/test_mqtt_roundtrip.py
@@ -73,7 +73,14 @@ def _put_and_wait(context, output_pv, input_pv, value, timeout=10.0):
         ("mqtt:test:StringOutput", "mqtt:test:StringInput", "epicsMQTT-ci"),
         ("mqtt:test:IntArrayOutput", "mqtt:test:IntArrayInput", [1, 2, 3, 4, 5]),
         ("mqtt:test:FloatArrayOutput", "mqtt:test:FloatArrayInput", [1.1, 2.2, 3.3, 4.4, 5.5]),
-    ],
+        ("mqtt:test:JsonInt32Output", "mqtt:test:JsonInt32Input", 42),
+        ("mqtt:test:JsonFloat64Output", "mqtt:test:JsonFloat64Input", 3.14159),
+        ("mqtt:test:JsonStringOutput", "mqtt:test:JsonStringInput", "epicsMQTT-ci"),
+        ("mqtt:test:JsonIntArrayOutput", "mqtt:test:JsonIntArrayInput", [1, 2, 3, 4, 5]),
+        ("mqtt:test:JsonFloatArrayOutput", "mqtt:test:JsonFloatArrayInput", [1.1, 2.2, 3.3, 4.4, 5.5]),
+        ("mqtt:test:JsonAltAddressOutput", "mqtt:test:JsonAltAdressInput", 43),
+        ("mqtt:test:JsonTemplateOutput", "mqtt:test:JsonTemplateInput", 44),
+     ],
 )
 def test_round_trip_via_broker(pva_context, output_pv, input_pv, value):
     _put_and_wait(pva_context, output_pv, input_pv, value)


### PR DESCRIPTION
This changelist replaces existing JSON handling, by using JSON pointer to address components within MQTT JSON message and configuration file to provide templates and alternative write addresses.

List of changes:

- Remove recursive JSON field discovery with JSON pointer
- [Optional] add clangd and E3 Makefile to gitignore
- Add a new IOC shell function that expands existing method with JSON configuration loader
- Add JSON configuration, removing redundant settings after some configurations are moved to JSON object.
- Refactor parseDeviceAddress to check first, and create object later.
- Add JSON composer and replace NotImplemented placeholders with JSON write feature
- Update README.

